### PR TITLE
Recognize p-type GPU instances too!

### DIFF
--- a/grafana/dashboards/gpu.json
+++ b/grafana/dashboards/gpu.json
@@ -1864,7 +1864,7 @@
           "value": "i-0edc71e97259faa4c"
         },
         "datasource": "prometheus",
-        "definition": "label_values(node_uname_info{job=~\"ec2_instances\",instance_type=~\"g[3-4].*\"}, instance_id)",
+        "definition": "label_values(node_uname_info{job=~\"ec2_instances\",instance_type=~\"[pg][2-4].*\"}, instance_id)",
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -1872,7 +1872,7 @@
         "multi": false,
         "name": "instance_id",
         "options": [],
-        "query": "label_values(node_uname_info{job=~\"ec2_instances\",instance_type=~\"g[3-4].*\"}, instance_id)",
+        "query": "label_values(node_uname_info{job=~\"ec2_instances\",instance_type=~\"[pg][2-4].*\"}, instance_id)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/parallelcluster-setup/install-monitoring.sh
+++ b/parallelcluster-setup/install-monitoring.sh
@@ -96,7 +96,7 @@ case "${cfn_node_type}" in
 
 	ComputeFleet)
 		compute_instance_type=$(ec2-metadata -t | awk '{print $2}')
-		gpu_instances="g[2-9].*\.[0-9]*[x]*large"
+		gpu_instances="[pg][2-9].*\.[0-9]*[x]*large"
 		if [[ $compute_instance_type =~ $gpu_instances ]]; then
 			distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
 			curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.repo | tee /etc/yum.repos.d/nvidia-docker.repo


### PR DESCRIPTION
This is my attempt to make the GPU monitoring work on p-type instances. p3 instances are indeed recognized and show up in the GPU Nodes list after applying this patch. Also, the nvidia-dcgm monitoring seems to be running on the nodes. 

However, I still don't see any GPU data in Grafana. Everything is showing "no data" or "N/A".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
