### PR TITLE
Pcluster 2.11.4 uses a different cfn_node_type

### DIFF
--- a/parallelcluster-setup/install-monitoring.sh
+++ b/parallelcluster-setup/install-monitoring.sh
@@ -26,7 +26,7 @@ echo "$> variable monitoring_home -> ${monitoring_home}"
 
 
 case "${cfn_node_type}" in
-	HeadNode)
+	HeadNode | MasterServer)
 
 		#cfn_efs=$(cat /etc/chef/dna.json | grep \"cfn_efs\" | awk '{print $2}' | sed "s/\",//g;s/\"//g")
 		#cfn_cluster_cw_logging_enabled=$(cat /etc/chef/dna.json | grep \"cfn_cluster_cw_logging_enabled\" | awk '{print $2}' | sed "s/\",//g;s/\"//g")

--- a/post-install.sh
+++ b/post-install.sh
@@ -17,7 +17,7 @@ setup_command=${cfn_postinstall_args[2]}
 monitoring_home="/home/${cfn_cluster_user}/${monitoring_dir_name}"
 
 case ${cfn_node_type} in
-    HeadNode)
+    MasterServer)
         wget ${monitoring_url} -O ${monitoring_tarball}
         mkdir -p ${monitoring_home}
         tar xvf ${monitoring_tarball} -C ${monitoring_home} --strip-components 1

--- a/post-install.sh
+++ b/post-install.sh
@@ -17,7 +17,7 @@ setup_command=${cfn_postinstall_args[2]}
 monitoring_home="/home/${cfn_cluster_user}/${monitoring_dir_name}"
 
 case ${cfn_node_type} in
-    MasterServer)
+    HeadNode | MasterServer)
         wget ${monitoring_url} -O ${monitoring_tarball}
         mkdir -p ${monitoring_home}
         tar xvf ${monitoring_tarball} -C ${monitoring_home} --strip-components 1


### PR DESCRIPTION
cfn_node_type =MasterServer

*[Issue #, if available:](https://github.com/aws-samples/aws-parallelcluster-monitoring/issues/19)*

https://github.com/aws-samples/aws-parallelcluster-monitoring/issues/19

*Description of changes:*
Fixing mismatch between pcluster expectation and the post install script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
