### PR TITLE
Adding support for p5.48xlarge and p4de.24xlarge instance types and Fix for FsX monitoring

### DIFF
--- a/parallelcluster-setup/install-monitoring.sh
+++ b/parallelcluster-setup/install-monitoring.sh
@@ -30,7 +30,7 @@ case "${cfn_node_type}" in
 
 		#cfn_efs=$(cat /etc/chef/dna.json | grep \"cfn_efs\" | awk '{print $2}' | sed "s/\",//g;s/\"//g")
 		#cfn_cluster_cw_logging_enabled=$(cat /etc/chef/dna.json | grep \"cfn_cluster_cw_logging_enabled\" | awk '{print $2}' | sed "s/\",//g;s/\"//g")
-		cfn_fsx_fs_id=$(cat /etc/chef/dna.json | grep \"cfn_fsx_fs_id\" | awk '{print $2}' | sed "s/\",//g;s/\"//g")
+		cfn_fsx_fs_id=$(cat /etc/chef/dna.json | grep \"fsx_fs_ids\" | awk '{print $2}' | sed "s/\",//g;s/\"//g")
 		master_instance_id=$(ec2-metadata -i | awk '{print $2}')
 		cfn_max_queue_size=$(aws cloudformation describe-stacks --stack-name $stack_name --region $cfn_region | jq -r '.Stacks[0].Parameters | map(select(.ParameterKey == "MaxSize"))[0].ParameterValue')
 		s3_bucket=$(echo $cfn_postinstall | sed "s/s3:\/\///g;s/\/.*//")

--- a/post-install.sh
+++ b/post-install.sh
@@ -14,7 +14,7 @@ monitoring_dir_name=aws-parallelcluster-monitoring
 monitoring_tarball="${monitoring_dir_name}.tar.gz"
 
 #get GitHub repo to clone and the installation script
-monitoring_url=https://github.com/aws-samples/aws-parallelcluster-monitoring/archive/refs/tags/${version}.tar.gz
+monitoring_url=https://github.com/gallanik/aws-parallelcluster-monitoring/archive/refs/tags/${version}.tar.gz
 setup_command=install-monitoring.sh
 monitoring_home="/home/${cfn_cluster_user}/${monitoring_dir_name}"
 

--- a/post-install.sh
+++ b/post-install.sh
@@ -14,7 +14,7 @@ monitoring_dir_name=aws-parallelcluster-monitoring
 monitoring_tarball="${monitoring_dir_name}.tar.gz"
 
 #get GitHub repo to clone and the installation script
-monitoring_url=https://github.com/gallanik/aws-parallelcluster-monitoring/archive/refs/tags/${version}.tar.gz
+monitoring_url=https://github.com/aws-samples/aws-parallelcluster-monitoring/archive/refs/tags/${version}.tar.gz
 setup_command=install-monitoring.sh
 monitoring_home="/home/${cfn_cluster_user}/${monitoring_dir_name}"
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -49,6 +49,8 @@ scrape_configs:
               - p3.16xlarge
               - p3dn.24xlarge
               - p4d.24xlarge
+              - p4de.24xlarge
+              - p5.48xlarge
               - g3s.xlarge
               - g3.4xlarge
               - g3.8xlarge


### PR DESCRIPTION
New GPU instance types added to the AWS instance family

*Issue #, if available:*

*Description of changes:*
Modified prometheus/prometheus.yml to add p4de.24xlarge and p5.48xlarge. These are new GPU instance types released by AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
