### PR TITLE
Support the monitoring stack on Ubuntu-based AWS PCS AMIs

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -80,7 +80,6 @@ case "${PLATFORM_NODE_TYPE}" in
             sed -i "s|__SLURMCTLD_IP__|${PCS_SLURMCTLD_IP}|g"     "${MONITORING_HOME}/prometheus/prometheus.yml"
             sed -i "s|__PCS_CLUSTER_ID__|${PCS_CLUSTER_ID}|g"     "${MONITORING_HOME}/prometheus/prometheus.yml"
             # Login node instance ID for the static scrape target.
-            local login_id
             login_id=$(curl -sf -H "X-aws-ec2-metadata-token: $(curl -sf -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)" \
                 http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || echo "unknown")
             sed -i "s|__LOGIN_INSTANCE_ID__|${login_id}|g"         "${MONITORING_HOME}/prometheus/prometheus.yml"

--- a/installer/platform/pcs.sh
+++ b/installer/platform/pcs.sh
@@ -58,11 +58,17 @@ _load_pcs() {
             --output text 2>/dev/null) || die "Could not resolve slurmctld endpoint"
     fi
 
+    # Detect the platform user. Ubuntu-based AMIs use 'ubuntu', AL2023 uses 'ec2-user'.
+    local platform_user="ec2-user"
+    if [[ -d /home/ubuntu ]] && id ubuntu >/dev/null 2>&1; then
+        platform_user="ubuntu"
+    fi
+
     export PLATFORM="pcs"
     export PLATFORM_NODE_TYPE="${node_type}"      # login | compute
     export PLATFORM_CLUSTER_NAME="${cluster_id}"
     export PLATFORM_REGION="${region}"
-    export PLATFORM_USER="ec2-user"               # AL2023 default
+    export PLATFORM_USER="${platform_user}"
 
     # PCS-specific
     export PCS_CLUSTER_ID="${cluster_id}"

--- a/post-install.sh
+++ b/post-install.sh
@@ -41,8 +41,12 @@ if [[ -r /etc/parallelcluster/cfnconfig ]]; then
     # shellcheck disable=SC2154  # cfn_cluster_user is set by cfnconfig
     CLUSTER_USER="${cfn_cluster_user}"
 else
-    # PCS / other: sample AMIs use ec2-user
+    # PCS / other: Detect the cluster user. Ubuntu-based AMIs use 'ubuntu',
+    # Amazon Linux 2023 uses 'ec2-user'.
     CLUSTER_USER="ec2-user"
+    if [[ -d /home/ubuntu ]] && id ubuntu >/dev/null 2>&1; then
+        CLUSTER_USER="ubuntu"
+    fi
 fi
 MONITORING_HOME="/home/${CLUSTER_USER}/${MONITORING_DIR_NAME}"
 


### PR DESCRIPTION
## Summary

Resolves #43.

Enables the monitoring stack to install cleanly on **Ubuntu-based AWS PCS AMIs** (validated on the PCS Ubuntu 24.04 DLAMI Base). The installer previously assumed an Amazon Linux 2023 environment (`ec2-user`), which broke on Ubuntu, where the OS user is `ubuntu`.

## Changes

- **`installer/install.sh`** — Remove the `local` keyword from the top-level `login_id` assignment in the PCS login-node branch. `local` outside a function raises `local: can only be used in a function` under Ubuntu's bash with `set -euo pipefail`.
- **`installer/platform/pcs.sh`** — Auto-detect the platform user: `ubuntu` when `/home/ubuntu` exists and the `ubuntu` user is present, otherwise the existing `ec2-user` default.
- **`post-install.sh`** — Apply the same auto-detection for `CLUSTER_USER` so the tarball is extracted into the correct home directory.

## Backward Compatibility

Fully backward compatible with Amazon Linux 2023: when `/home/ubuntu` is absent, the `ec2-user` default is preserved. No changes to the ParallelCluster (`pcluster`) code path.

## Validation

Tested end-to-end on a minimal PCS cluster:

- Platform: AWS Parallel Computing Service (PCS)
- OS: Ubuntu 24.04.4 LTS (PCS DLAMI Base)
- Instance: m6i.xlarge (login node), Slurm 25.11

Results after the change:

- ✅ Installer completes with exit code 0
- ✅ Platform user correctly detected as `ubuntu` (`PLATFORM_USER=ubuntu`, `MONITORING_HOME=/home/ubuntu/aws-parallelcluster-monitoring`)
- ✅ `login_id` resolves without the `local` error
- ✅ All monitoring containers start: nginx, prometheus, grafana, cloudwatch-exporter, node-exporter, pushgateway
- ✅ Grafana admin password stored in SSM Parameter Store

Because the fixes depend only on the OS-user convention and bash behavior — not on anything DLAMI-specific — the same result is expected on other Ubuntu-based PCS AMIs.
