### PR TITLE
PCS: fix login dashboard 422 and free the Name tag via monitoring-role

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,14 @@ Ensure your security group allows port 6817 from the login node to the slurmctld
 
 ### 2. Configure launch templates
 
+Node type (login vs compute) is determined by the `monitoring-role` tag, not by
+`Name`. The `Name` tag is free for arbitrary operator use. Login nodes
+(`monitoring-role=login`) are excluded from EC2 service discovery and scraped by
+the static `login_node` job as `instance_name=HeadNode`; every other discovered
+node is reported as `instance_name=Compute`.
+
 **Login node** launch template (runs the monitoring stack):
-- Tag: `Name=HeadNode`, `monitoring-role=login`, `pcs-cluster-id=<cluster-id>`
+- Tag: `monitoring-role=login`, `pcs-cluster-id=<cluster-id>` (`Name` is free)
 - `MetadataOptions.InstanceMetadataTags=enabled`
 - User data (MIME multipart):
 
@@ -157,7 +163,8 @@ bash /tmp/post-install.sh latest
 ```
 
 **Compute node** launch template (runs node_exporter + dcgm-exporter):
-- Tag: `Name=Compute`
+- Tag: `monitoring-role=compute` (optional — a node with no `monitoring-role`
+  tag is treated as compute; `Name` is free)
 - `MetadataOptions.InstanceMetadataTags=enabled`
 - Same user data as above
 

--- a/grafana/dashboards/gpu-health.json
+++ b/grafana/dashboards/gpu-health.json
@@ -134,7 +134,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(count_over_time(DCGM_FI_DEV_XID_ERRORS{}[1h]) > 0) or vector(0)",
+          "expr": "count(max_over_time(DCGM_FI_DEV_XID_ERRORS{}[1h]) > 0) or vector(0)",
           "instant": true
         }
       ],

--- a/prometheus/prometheus-pcs.yml
+++ b/prometheus/prometheus-pcs.yml
@@ -116,6 +116,24 @@ scrape_configs:
           - name: instance-state-name
             values: [running]
     relabel_configs:
+      # Drop login/head nodes from EC2 service discovery. They are already
+      # scraped by the static 'login_node' job (localhost:9100) with
+      # instance_name=HeadNode. On PCS the login node group also carries the
+      # aws:pcs:cluster-id tag this job filters on, so without this drop the
+      # login node is discovered here too and scraped a second time, producing
+      # duplicate node_uname_info series for one instance_id and breaking the
+      # Login Node dashboards' `* on(instance_id) group_left(...)` joins with
+      # "many-to-many matching not allowed" (HTTP 422). See issue #45.
+      #
+      # Login nodes are identified by the monitoring-role=login tag (the same
+      # tag installer/platform/pcs.sh reads via IMDS to pick the node type).
+      # Nodes without a monitoring-role tag (legacy clusters, or CNGs deployed
+      # with MonitoringRole=none) present an empty string here, which does NOT
+      # match 'login', so they are kept and treated as compute. This frees the
+      # EC2 'Name' tag for arbitrary operator use.
+      - source_labels: [__meta_ec2_tag_monitoring_role]
+        regex: login
+        action: drop
       - source_labels: [__meta_ec2_tag_aws_pcs_compute_node_group_id]
         target_label: node_group_id
       - source_labels: [__meta_ec2_instance_id]
@@ -128,11 +146,16 @@ scrape_configs:
         target_label: instance_type
       - source_labels: [__meta_ec2_vpc_id]
         target_label: instance_vpc
-      # Dashboards filter by instance_name='HeadNode' or 'Compute'.
-      # For PCS: the launch template should tag Name=HeadNode on login
-      # and Name=Compute on compute nodes (legacy convention).
-      - source_labels: [__meta_ec2_tag_Name]
+      # Everything reaching this point is a compute node (login was dropped
+      # above). The Grafana dashboards filter on the literal instance_name
+      # values "HeadNode" (served only by the static 'login_node' job) and
+      # "Compute" (served here), so we hardcode instance_name=Compute rather
+      # than deriving it from the Name tag. This frees the Name tag for
+      # arbitrary use and is backward compatible: legacy compute nodes
+      # (Name=Compute) resolve to the same value.
+      - source_labels: []
         target_label: instance_name
+        replacement: Compute
       # Surface the PCS compute-node-group ID as 'pc_queue' so the same
       # dashboards (which group/sort by queue on PC) work on PCS.
       # (Avoiding the bare 'queue' label name because node_exporter


### PR DESCRIPTION
Fixes #45.

## Problem

On **AWS PCS**, the Login Node dashboards fail with a Prometheus
`many-to-many matching not allowed` error (HTTP 422), and node-type selection is
coupled to the user-facing `Name` tag.

`prometheus/prometheus-pcs.yml` scrapes the login node twice: via the static
**`login_node`** job (`localhost:9100`, hardcoding `instance_name=HeadNode`) and
via the **`ec2_instances`** EC2 SD job (filtering on `tag:aws:pcs:cluster-id`).
The `login_node` job assumed the login node doesn't get the `aws:pcs:cluster-id`
tag, but a **PCS-managed login node group does carry it**, so the node is
discovered by both jobs. Both emit `node_uname_info{instance_name="HeadNode"}`
for the same `instance_id`, so the dashboard `group_left` joins match two series
→ 422.

Separately, deriving `instance_name` from `Name` forces operators to set
`Name=HeadNode`/`Compute`, but on PCS `Name` is legitimately theirs to set.

## Fix

Keyed on the existing **`monitoring-role`** tag (already read by
`installer/platform/pcs.sh`), as suggested in #45:

- **Drop `monitoring-role=login` from the `ec2_instances` relabel chain** so the
  login node is scraped only by the static `login_node` job (removes the
  duplicate series → fixes the 422). A node with no `monitoring-role` tag
  presents an empty string, does not match `login`, and is kept — so legacy
  clusters keep working.
- **Set `instance_name=Compute` as a constant** for everything left in EC2 SD
  instead of deriving it from `Name`. This frees `Name`; dashboards (which filter
  on the ParallelCluster-convention `instance_name` values `HeadNode`/`Compute`)
  are unchanged and stay backward compatible with legacy `Name=Compute` nodes.
- README: document `monitoring-role` as the node-type selector and that `Name`
  is free.

No dashboard changes; contained to `prometheus-pcs.yml` + README.

## Verification

Tested end-to-end on a PCS cluster (Ubuntu 24.04 DLAMI) with login and compute
nodes carrying **arbitrary** `Name` tags:

- `count by(instance_id)(node_uname_info{instance_name="HeadNode"})` = **1**
  (was **2**); login dashboard join now **succeeds** (was HTTP 422).
- A compute node with `Name=PCS-cpu1` is reported as `instance_name=Compute`;
  `count by(instance_name)(node_uname_info)` = `HeadNode`(1) + `Compute`(1) only.
- Retagging the login node's `Name` to an arbitrary value keeps it correctly
  dropped — confirming `Name` no longer affects monitoring.

## Note

`test-clusters/pcs-create.sh` still discovers the login node via
`tag:Name,Values=HeadNode` (and tags `Name=HeadNode`/`Compute`). That keeps
working as-is, but is inconsistent with "Name is free" — if you'd like, I can
follow up to switch that discovery to `tag:monitoring-role,Values=login`. Left
out of this PR to keep it focused.
