### PR TITLE
PCS: install monitoring on node-local /opt, not shared /home (fix Stale file handle race)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ aws ssm put-parameter \
     }'
 
 # 3. Re-run the installer (or recreate the cluster)
-sudo bash /home/ec2-user/aws-parallelcluster-monitoring/installer/install.sh
+sudo bash /opt/aws-parallelcluster-monitoring/installer/install.sh
 sudo docker restart grafana
 ```
 

--- a/cognito/README.md
+++ b/cognito/README.md
@@ -76,7 +76,7 @@ re-run the installer manually:
 
 ```bash
 # On the HeadNode (via SSH or SSM Session Manager)
-sudo bash /home/ec2-user/aws-parallelcluster-monitoring/installer/install.sh
+sudo bash /opt/aws-parallelcluster-monitoring/installer/install.sh
 sudo docker restart grafana
 ```
 
@@ -121,7 +121,7 @@ aws ssm delete-parameter --region <region> \
     --name /parallelcluster/<cluster>/grafana/cognito
 
 # On the HeadNode:
-sudo bash /home/ec2-user/aws-parallelcluster-monitoring/installer/install.sh
+sudo bash /opt/aws-parallelcluster-monitoring/installer/install.sh
 sudo docker restart grafana
 ```
 

--- a/compose/compute.gpu.yml
+++ b/compose/compute.gpu.yml
@@ -33,7 +33,7 @@ services:
       - "-f"
       - "/etc/dcgm-exporter/counters.csv"
     volumes:
-      - "/home/${cfn_cluster_user}/__MONITORING_DIR__/dcgm/counters.csv:/etc/dcgm-exporter/counters.csv:ro"
+      - "__MONITORING_HOME__/dcgm/counters.csv:/etc/dcgm-exporter/counters.csv:ro"
     deploy:
       resources:
         reservations:

--- a/compose/head.yml
+++ b/compose/head.yml
@@ -22,8 +22,8 @@ services:
       # Required because Imds.Secured=true blocks non-root IMDS access inside containers.
       - 'AWS_SHARED_CREDENTIALS_FILE=/run/prometheus-ec2-creds/credentials'
     volumes:
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml'
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/prometheus/rules:/etc/prometheus/rules:ro'
+      - '__MONITORING_HOME__/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml'
+      - '__MONITORING_HOME__/prometheus/rules:/etc/prometheus/rules:ro'
       - 'prometheus-data:/prometheus'
       - '/run/prometheus-ec2-creds:/run/prometheus-ec2-creds:ro'
     image: prom/prometheus:v3.1.0
@@ -53,7 +53,7 @@ services:
       # Empty file when Cognito is not configured (no-op).
       - '/run/grafana-secrets/cognito.env'
     volumes:
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/grafana:/etc/grafana/provisioning'
+      - '__MONITORING_HOME__/grafana:/etc/grafana/provisioning'
       - 'grafana-data:/var/lib/grafana'
       - '/run/grafana-secrets:/run/grafana-secrets:ro'
     image: grafana/grafana:11.2.2
@@ -79,9 +79,9 @@ services:
     pid: host
     restart: unless-stopped
     volumes:
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/nginx/conf.d:/etc/nginx/conf.d/'
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/nginx/ssl:/etc/ssl/'
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/www:/usr/share/nginx/html'
+      - '__MONITORING_HOME__/nginx/conf.d:/etc/nginx/conf.d/'
+      - '__MONITORING_HOME__/nginx/ssl:/etc/ssl/'
+      - '__MONITORING_HOME__/www:/usr/share/nginx/html'
     image: nginx:1.27-alpine
 
   cloudwatch-exporter:
@@ -92,7 +92,7 @@ services:
     environment:
       - 'AWS_SHARED_CREDENTIALS_FILE=/run/prometheus-ec2-creds/credentials'
     volumes:
-      - '/home/${cfn_cluster_user}/__MONITORING_DIR__/cloudwatch-exporter/config.yml:/config/config.yml:ro'
+      - '__MONITORING_HOME__/cloudwatch-exporter/config.yml:/config/config.yml:ro'
       - '/run/prometheus-ec2-creds:/run/prometheus-ec2-creds:ro'
     image: prom/cloudwatch-exporter:v0.16.0
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -20,7 +20,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 detect_platform
 
 MONITORING_DIR_NAME="aws-parallelcluster-monitoring"
-MONITORING_HOME="/home/${PLATFORM_USER}/${MONITORING_DIR_NAME}"
+# Derive MONITORING_HOME from where this script actually lives (the extracted
+# tree's installer/ dir → its parent), so it works wherever post-install.sh
+# extracted it. NOTE: this must be node-LOCAL (post-install.sh uses /opt), never
+# the shared /home — see the Stale-file-handle note in post-install.sh.
+MONITORING_HOME="$(cd "${SCRIPT_DIR}/.." && pwd)"
 export MONITORING_HOME MONITORING_DIR_NAME
 
 log "Platform: ${PLATFORM}"
@@ -52,7 +56,7 @@ case "${PLATFORM_NODE_TYPE}" in
 
         # Extract context from chef dna.json and CloudFormation.
 
-        chown "${PLATFORM_USER}:${PLATFORM_USER}" -R "/home/${PLATFORM_USER}"
+        chown "${PLATFORM_USER}:${PLATFORM_USER}" -R "${MONITORING_HOME}"
         chmod +x "${MONITORING_HOME}/custom-metrics/"*
 
         cp -rp "${MONITORING_HOME}/custom-metrics/"* /usr/local/bin/
@@ -88,7 +92,7 @@ case "${PLATFORM_NODE_TYPE}" in
         fi
         sed -i "s/__AWS_REGION__/${PLATFORM_REGION}/g"        "${MONITORING_HOME}/prometheus/prometheus.yml"
         sed -i "s/__AWS_REGION__/${PLATFORM_REGION}/g"        "${MONITORING_HOME}/cloudwatch-exporter/config.yml"
-        sed -i "s|__MONITORING_DIR__|${MONITORING_DIR_NAME}|g" "${MONITORING_HOME}/compose/head.yml"
+        sed -i "s|__MONITORING_HOME__|${MONITORING_HOME}|g" "${MONITORING_HOME}/compose/head.yml"
 
         # Deploy platform-specific dashboards alongside the shared ones,
         # then remove the OTHER platform's subdirectory entirely (Grafana
@@ -249,18 +253,13 @@ COGENV
         systemctl enable --now prometheus-creds-refresh.timer
         log "EC2 credential refresh timer active"
 
-        # Start the monitoring stack.
-        # Generate a compose env file with the variables head.yml references.
-        # We must export cfn_cluster_user (legacy name used throughout the
-        # compose file) regardless of platform to avoid rewriting the file.
-        cat > /tmp/compose.env <<ENVFILE
-cfn_cluster_user=${PLATFORM_USER}
-ENVFILE
+        # Start the monitoring stack. Bind-mount source paths are resolved by
+        # the __MONITORING_HOME__ substitution above (node-local /opt path), so
+        # no compose env file is needed.
         cd "${MONITORING_HOME}"
-        docker compose --env-file /tmp/compose.env \
+        docker compose \
             -f "${MONITORING_HOME}/compose/head.yml" \
             -p monitoring-head up -d
-        rm -f /tmp/compose.env
 
         # Slurm job-to-node textfile collector (Phase 3c).
         # Runs every 30s, writes /var/lib/prometheus/node-exporter/slurm_jobs.prom
@@ -308,17 +307,13 @@ ENVFILE
             nvidia-ctk runtime configure --runtime=docker
             systemctl restart docker
 
-            # compute.gpu.yml needs cfn_cluster_user (for the dcgm
-            # counters bind-mount) and __MONITORING_DIR__ substituted.
-            sed -i "s|__MONITORING_DIR__|${MONITORING_DIR_NAME}|g" \
+            # compute.gpu.yml's dcgm counters bind-mount resolves via the
+            # __MONITORING_HOME__ substitution (node-local /opt path).
+            sed -i "s|__MONITORING_HOME__|${MONITORING_HOME}|g" \
                 "${MONITORING_HOME}/compose/compute.gpu.yml"
-            cat > /tmp/compose.env <<ENVFILE
-cfn_cluster_user=${PLATFORM_USER}
-ENVFILE
-            docker compose --env-file /tmp/compose.env \
+            docker compose \
                 -f "${MONITORING_HOME}/compose/compute.gpu.yml" \
                 -p monitoring-compute up -d
-            rm -f /tmp/compose.env
         else
             docker compose -f "${MONITORING_HOME}/compose/compute.yml" \
                 -p monitoring-compute up -d

--- a/post-install.sh
+++ b/post-install.sh
@@ -48,7 +48,14 @@ else
         CLUSTER_USER="ubuntu"
     fi
 fi
-MONITORING_HOME="/home/${CLUSTER_USER}/${MONITORING_DIR_NAME}"
+# Install the monitoring tree on NODE-LOCAL disk, NOT under /home.
+# On AWS PCS, /home is a SHARED filesystem (FSx for OpenZFS over NFS) mounted on
+# every node. Extracting/owning/sed-ing the tree there makes the login node and
+# every compute node race on the same files at first boot, which intermittently
+# fails with "error reading input file: Stale file handle" (one node's tar
+# replaces an inode another node is mid-read). /opt is local to each node, so
+# each install is independent.
+MONITORING_HOME="/opt/${MONITORING_DIR_NAME}"
 
 # Fetch the tarball. /archive supports both tag and branch paths.
 fetch_tarball() {


### PR DESCRIPTION
## Problem

On **AWS PCS**, the monitoring installer extracts, `chown`s and `sed`s the
monitoring tree under `/home/${USER}/aws-parallelcluster-monitoring`. But on PCS
`/home` is a **shared filesystem** (FSx for OpenZFS over NFS) mounted on *every*
node. At first boot the login node and all compute nodes run `post-install.sh`
concurrently against the **same** files, so one node's `tar`/`chown` replaces an
inode another node is mid-read. The losing node fails with:

```
installer/install.sh: error reading input file: Stale file handle
```

and is left without monitoring (its node-exporter/dcgm-exporter never start,
Prometheus shows the target down, dashboards are empty for that node). It's
timing-dependent, so which node loses varies between deploys.

(On ParallelCluster `/home` is also shared, so the same race is possible there
when ComputeFleet and HeadNode bootstrap together; PCS just hits it reliably
because every node runs the same entrypoint at the same time.)

## Fix

Install the monitoring tree on **node-local `/opt`** instead of the shared
`/home`, so each node's install is independent:

- **`post-install.sh`**: `MONITORING_HOME=/opt/aws-parallelcluster-monitoring`.
- **`installer/install.sh`**: derive `MONITORING_HOME` from the script's own
  location (`SCRIPT_DIR/..`) so it works wherever it was extracted; `chown` only
  the monitoring tree instead of all of `/home/$USER`; substitute
  `__MONITORING_HOME__`.
- **`compose/head.yml`**, **`compose/compute.gpu.yml`**: resolve bind-mount
  source paths via a `__MONITORING_HOME__` token (was
  `/home/${cfn_cluster_user}/__MONITORING_DIR__`). The per-platform compose env
  file is no longer needed and is dropped.
- **README / cognito docs**: manual re-run path updated to `/opt`.

No behavior change other than the install location; the Grafana SSM password,
exporters, dashboards, and compose project names are unchanged.

## Verification

Re-ran the new installer **simultaneously on all 3 nodes** (1 login + 2 compute,
p6-class GPU) — i.e. the exact race that triggered the bug — on real PCS hardware:

- all three `EXIT=0`, no Stale file handle;
- tree present under `/opt`, `/home` clean;
- login node: prometheus / grafana / nginx / cloudwatch-exporter / pushgateway /
  node-exporter all up; compute nodes: dcgm-exporter + node-exporter up;
- Prometheus: all `:9100`/`:9400` targets `up`, GPUs reporting DCGM metrics.