### PR TITLE
GPU monitoring: repin dcgm-exporter for Docker 29.x, drop misleading throttle tiles

### DIFF
--- a/compose/compute.gpu.yml
+++ b/compose/compute.gpu.yml
@@ -23,7 +23,12 @@ services:
     network_mode: host
     pid: host
     restart: unless-stopped
-    image: nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04
+    # Pinned to the newest tag whose manifest is a Docker manifest-list v2.
+    # From 4.2.3 onward NVCR publishes an OCI image index with attestation/SBOM
+    # manifests, which Docker 29.x cannot pull ("error from registry: Incorrect
+    # Repository Format"), leaving GPU nodes with no dcgm-exporter. 4.2.0-4.1.0
+    # pulls cleanly on Docker 29.x and emits the same DCGM_FI_DEV_* fields. See #47.
+    image: nvcr.io/nvidia/k8s/dcgm-exporter:4.2.0-4.1.0-ubuntu22.04
     # Custom counters file enables XID errors, throttle reasons,
     # ECC counters, retired pages, full NVLink error set, and the
     # DCP profiling metrics (SM_ACTIVE / SM_OCCUPANCY / TENSOR / FP64 /

--- a/grafana/dashboards/gpu-health.json
+++ b/grafana/dashboards/gpu-health.json
@@ -170,111 +170,11 @@
     },
     {
       "type": "stat",
-      "title": "GPUs with thermal throttle (last 1h)",
-      "gridPos": {
-        "h": 4,
-        "w": 5,
-        "x": 9,
-        "y": 1
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "count(rate(DCGM_FI_DEV_THERMAL_VIOLATION[1h]) > 0) or vector(0)",
-          "instant": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "noValue": "0"
-        }
-      },
-      "options": {
-        "textMode": "value",
-        "colorMode": "background",
-        "graphMode": "none",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      }
-    },
-    {
-      "type": "stat",
-      "title": "GPUs with power throttle (last 1h)",
-      "gridPos": {
-        "h": 4,
-        "w": 5,
-        "x": 14,
-        "y": 1
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "count(rate(DCGM_FI_DEV_POWER_VIOLATION[1h]) > 0) or vector(0)",
-          "instant": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "noValue": "0"
-        }
-      },
-      "options": {
-        "textMode": "value",
-        "colorMode": "background",
-        "graphMode": "none",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      }
-    },
-    {
-      "type": "stat",
       "title": "GPUs with row-remap failure",
       "gridPos": {
         "h": 4,
         "w": 5,
-        "x": 19,
+        "x": 9,
         "y": 1
       },
       "targets": [


### PR DESCRIPTION
Fixes the two remaining items in #47 (the XID summary-tile false-positive was
already fixed in #46).

## 1. dcgm-exporter tag not pullable on Docker 29.x

`compose/compute.gpu.yml` pinned `nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04`.
From tag **4.2.3 onward**, NVCR publishes an **OCI image index** with
attestation/SBOM manifests, which **Docker 29.x cannot pull**:

```
error from registry: Incorrect Repository Format
```

So on a host running Docker 29.x the GPU compute nodes end up with **no
dcgm-exporter**, and the GPU dashboards are empty.

This repins to **`4.2.0-4.1.0-ubuntu22.04`** — the newest tag whose manifest is
still a plain Docker manifest-list v2. Verified it pulls cleanly on Docker 29.5.2
and emits the same `DCGM_FI_DEV_*` fields the dashboards use.

## 2. Misleading "thermal/power throttle" summary tiles

`grafana/dashboards/gpu-health.json` had two GPU Health summary stat tiles
counting `rate(DCGM_FI_DEV_*_VIOLATION[1h]) > 0`. But
`DCGM_FI_DEV_*_THROTTLE_VIOLATION` are **monotonic accumulated-throttle-time
counters**, so any GPU that has ever throttled shows a non-zero rate — healthy
H100s (power throttling especially) are flagged essentially always (verified
16/16 GPUs flagged red on an idle cluster). The tiles are removed; the per-node
throttle **time-series** panels below them are kept, since as relative trends
they're still useful.

## Verification

Deployed on real PCS GPU hardware (Docker 29.5.2): dcgm-exporter pulls and runs,
Prometheus `:9400` target up, `DCGM_FI_DEV_*` metrics present, GPU dashboards
populated, and the GPU Health summary no longer false-flags idle GPUs.