### PR TITLE
dcgm-exporter: make the image configurable via DCGM_EXPORTER_IMAGE (fixes #50)

### DIFF
--- a/compose/compute.gpu.yml
+++ b/compose/compute.gpu.yml
@@ -29,12 +29,16 @@ services:
     network_mode: host
     pid: host
     restart: unless-stopped
-    # Pinned to the newest tag whose manifest is a Docker manifest-list v2.
-    # From 4.2.3 onward NVCR publishes an OCI image index with attestation/SBOM
-    # manifests, which Docker 29.x cannot pull ("error from registry: Incorrect
-    # Repository Format"), leaving GPU nodes with no dcgm-exporter. 4.2.0-4.1.0
-    # pulls cleanly on Docker 29.x and emits the same DCGM_FI_DEV_* fields. See #47.
-    image: nvcr.io/nvidia/k8s/dcgm-exporter:4.2.0-4.1.0-ubuntu22.04
+    # Image is overridable via DCGM_EXPORTER_IMAGE; the default below is the
+    # newest tag whose manifest is a Docker manifest-list v2. From 4.2.3 onward
+    # NVCR publishes an OCI image index with attestation/SBOM manifests, which
+    # Docker 29.x cannot pull ("error from registry: Incorrect Repository
+    # Format"), leaving GPU nodes with no dcgm-exporter. 4.2.0-4.1.0 pulls cleanly
+    # on Docker 29.x and emits the same DCGM_FI_DEV_* fields. See #47.
+    # The default covers up to B200; B300 (and future GPUs) need DCGM >= 4.4.0 --
+    # set DCGM_EXPORTER_IMAGE to a newer build, by DIGEST to bypass the Docker
+    # 29.x OCI-index pull failure (a digest pull skips index negotiation). See #50.
+    image: ${DCGM_EXPORTER_IMAGE:-nvcr.io/nvidia/k8s/dcgm-exporter:4.2.0-4.1.0-ubuntu22.04}
     # Custom counters file enables XID errors, throttle reasons,
     # ECC counters, retired pages, full NVLink error set, and the
     # DCP profiling metrics (SM_ACTIVE / SM_OCCUPANCY / TENSOR / FP64 /

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -354,6 +354,11 @@ COGENV
             # __MONITORING_HOME__ substitution (node-local /opt path).
             sed -i "s|__MONITORING_HOME__|${MONITORING_HOME}|g" \
                 "${MONITORING_HOME}/compose/compute.gpu.yml"
+            # Allow the dcgm-exporter image to be overridden (e.g. a B300-capable
+            # DCGM >= 4.4.0 build, supplied by digest to bypass the Docker 29.x
+            # OCI-index pull failure). compute.gpu.yml defaults to the safe 4.2.0
+            # pin when this is unset, so existing behaviour is unchanged. See #50.
+            export DCGM_EXPORTER_IMAGE="${DCGM_EXPORTER_IMAGE:-}"
             docker compose \
                 -f "${MONITORING_HOME}/compose/compute.gpu.yml" \
                 -p monitoring-compute up -d


### PR DESCRIPTION
## Summary

Make the `dcgm-exporter` image **configurable via the `DCGM_EXPORTER_IMAGE` environment variable**, defaulting to the current safe pin. This lets deployments on newer GPUs (e.g. B300 / p6-b300, which needs DCGM ≥ 4.4.0) supply a capable build — by digest — without forking the repo.

Fixes #50.

## Background

`compose/compute.gpu.yml` hardcodes `nvcr.io/nvidia/k8s/dcgm-exporter:4.2.0-4.1.0-ubuntu22.04`. That pin is deliberate (from #47/#49): it's the newest tag that pulls cleanly on Docker 29.x, since NVCR tags ≥ 4.2.3 publish an OCI image index whose attestation manifests `docker pull <tag>` trips on. But DCGM 4.2.0 only covers up to **B200** — **B300 needs DCGM ≥ 4.4.0** ([changelog](https://docs.nvidia.com/datacenter/dcgm/latest/release-notes/changelog.html): B300 support landed in 4.4.0). So B300 GPU nodes come up but their dashboards stay empty, with no fix short of editing the compose file in a fork.

## Change

Parameterize the image, default unchanged:

```yaml
# compose/compute.gpu.yml
image: ${DCGM_EXPORTER_IMAGE:-nvcr.io/nvidia/k8s/dcgm-exporter:4.2.0-4.1.0-ubuntu22.04}
```

`installer/install.sh` exports the variable before the GPU `docker compose up` so an operator-provided value (e.g. from launch-template user-data) flows through; unset → the compose default. This uses the **current `/opt` install path** (the `--env-file` mechanism referenced in the issue was removed in v2.6.4/#48, as you noted).

- **Backward compatible** — nothing set → the existing 4.2.0 pin, so #47/#49 behavior is unchanged.
- **No fork needed** — new-hardware users override one variable.
- The default stays inline in the compose file too, so a manual `docker compose up` on a node still works without the installer.

## Test Plan / Results — validated on real B300 hardware

Deployed on a live AWS PCS cluster (**2× p6-b300.48xlarge = 16× B300**, Slurm 25.11, us-west-2, Capacity Block, PCS-ready DLAMI Ubuntu 24.04, **Docker 29.5.3**, driver 595.71.05), with `DCGM_EXPORTER_IMAGE` set to the B300-capable DCGM 4.5.2 image **by digest**:

```
nvcr.io/nvidia/k8s/dcgm-exporter@sha256:a7ad6547d4546eaf4dd5d6b4c0b4db4101e63ef7dc3cdff7f42b767d2c60b706
```
(the linux/amd64 manifest for `4.5.2-4.8.1-ubuntu22.04`)

Results:
- **Digest pull succeeds on Docker 29.5.3** where the tag fails — the digest pull skips the OCI-index negotiation that breaks tag pulls (#47/#49). Container `Up`, `dcgm-exporter version 4.5.2-4.8.1`.
- **B300 GPU metrics flow**: `:9400/metrics` emits 312 `DCGM_FI_*` series, e.g.
  `DCGM_FI_DEV_SM_CLOCK{gpu="0",modelName="NVIDIA B300 SXM6 AC",...}`, plus
  `DCGM_FI_DEV_GPU_TEMP/POWER_USAGE/FB_USED/NVLINK_BANDWIDTH_TOTAL` and the
  `DCGM_FI_PROF_*` set (`SM_ACTIVE`, `PIPE_TENSOR_ACTIVE`, `DRAM_ACTIVE`, ...) that
  the `gpu.json` / `gpu-health.json` dashboards consume.
- **Backward compatibility**: a separate 2× p6-b200 deploy with `DCGM_EXPORTER_IMAGE` **unset** used the default 4.2.0 pin exactly as before and reported B200 GPU metrics — no change to existing behavior.

## Note on field coverage (re: your dashboards/counters heads-up)

I diffed the `dcgm/counters.csv` fields against what DCGM 4.5.2 emits on B300. The DCP/`DCGM_FI_PROF_*` profiling fields and the standard `DCGM_FI_DEV_*` device fields the dashboards use are all present. Two `counters.csv` entries report no value on the (healthy) B300 nodes — `DCGM_FI_DEV_XID_ERRORS` and `DCGM_FI_DEV_RETIRED_DBE` — but I confirmed this is **not** a 4.5.2/B300 field removal:
- `DCGM_FI_DEV_XID_ERRORS` (field 230) still exists in 4.5.2 (`dcgmi dmon -l` lists it) and is loaded by the exporter.
- `dcgmi dmon -e 230` returns `N/A` on all 8 GPUs because no XID has occurred (healthy GPUs) — it is a "value of the *last* XID error" gauge — and DCGM's XID detection parses host `/dev/kmsg`, which isn't mapped into the exporter container. `dmesg` on the host shows no Xid events.

So this is expected "no error yet" behavior, not a regression, and needs no dashboard/counters change for this PR. Flagging per your request in case you want to map `/dev/kmsg` into the GPU compose service separately so a real XID would surface.

## Checklist

- [x] Backward compatible (default pin unchanged when the var is unset).
- [x] External dependency override is by digest in the documented example (reproducible, and bypasses the Docker 29.x tag-pull issue).
- [x] Uses the current `/opt` install path, not the removed `--env-file` mechanism.
- [x] Validated on real B300 hardware (digest override) and B200 (default, backward compat).
