### PR TITLE
fix: restart prometheus on credential rotation so ec2_sd keeps discovering nodes

### DIFF
--- a/custom-metrics/refresh-ec2-credentials.sh
+++ b/custom-metrics/refresh-ec2-credentials.sh
@@ -63,14 +63,20 @@ chmod 0644 "${TMP_FILE}"
 chown root:root "${TMP_FILE}"
 
 # Detect whether the IMDS access key actually rotated (IMDS rotates role
-# creds roughly every ~6h). Prometheus re-reads the credentials file on
-# every ec2_sd refresh, so it never goes stale. But long-running JVM/Go
-# consumers — the cloudwatch-exporter and Grafana's CloudWatch datasource —
-# load the credentials provider once at startup and cache it in memory,
-# so when the underlying token expires their CloudWatch calls start
-# returning 403 "security token expired" and the Storage / Logs dashboards
-# go blank. Restart those two containers, but only when the key actually
-# changed, to avoid needless churn on every 5-minute tick.
+# creds roughly every ~6h). Long-running consumers load the AWS credentials
+# provider once at startup and cache it in memory, so when the underlying
+# session token expires their AWS calls start failing until the process is
+# restarted:
+#   - cloudwatch-exporter / Grafana CloudWatch datasource — 403 "security
+#     token expired"; Storage / Logs dashboards go blank.
+#   - prometheus ec2_sd — the AWS SDK for Go used by ec2_sd_config caches the
+#     shared-credentials file in-process and does NOT re-read it when the
+#     token expires, so DescribeInstances returns "RequestExpired: Request has
+#     expired" (misreported as a clock-skew error) and EC2 service discovery
+#     stops finding compute nodes — node/GPU/EFA metrics silently disappear
+#     while the login-local targets (slurm exporter, HeadNode) still look fine.
+# So restart all three on key rotation, but only when the key actually changed,
+# to avoid needless churn on every 5-minute tick.
 OLD_KEY=""
 if [[ -r "${CREDS_FILE}" ]]; then
     OLD_KEY=$(awk -F'= *' '/aws_access_key_id/{print $2; exit}' "${CREDS_FILE}" 2>/dev/null || echo "")
@@ -78,10 +84,10 @@ fi
 mv -f "${TMP_FILE}" "${CREDS_FILE}"
 
 if [[ "${AWS_ACCESS_KEY_ID}" != "${OLD_KEY}" && -n "${OLD_KEY}" ]]; then
-    # Key rotated since last run — bounce the CloudWatch consumers so they
+    # Key rotated since last run — bounce the AWS-credential consumers so they
     # pick up the new credentials. Ignore errors (containers may not exist
     # on compute nodes; this script only does meaningful work on head/login).
-    for c in cloudwatch-exporter grafana; do
+    for c in prometheus cloudwatch-exporter grafana; do
         docker restart "${c}" >/dev/null 2>&1 || true
     done
 fi


### PR DESCRIPTION
## What happens

`refresh-ec2-credentials.sh` restarts `cloudwatch-exporter` and `grafana` when the IMDS role credentials rotate (~every 6h), but **not `prometheus`** — on the assumption that *"Prometheus re-reads the credentials file on every ec2_sd refresh, so it never goes stale."*

That assumption doesn't hold. Prometheus's `ec2_sd_config` uses the AWS SDK for Go, which reads `AWS_SHARED_CREDENTIALS_FILE` **once at startup and caches the provider in-process**; it never re-reads the rotated file. So ~6h after the container starts, `DescribeInstances` fails and EC2 service discovery stops finding compute nodes:

```
discovery=ec2 err="... DescribeInstances, Probable clock skew error:
  ... RequestExpired: Request has expired."
```

(The "clock skew" message is misleading — the host clock is fine; the cached session token has simply expired. With a deliberately invalidated token the SDK instead returns `AuthFailure`.)

It is easy to miss: the login/head-local **static** targets (the Slurm OpenMetrics exporter and the HeadNode node-exporter) keep reporting, so Grafana still looks healthy, while **every EC2-discovered compute target (node-exporter `:9100`, dcgm-exporter `:9400`) silently disappears** and the node/GPU/EFA dashboards go blank.

## How it's fixed

Add `prometheus` to the containers restarted on key rotation, next to `cloudwatch-exporter` and `grafana` (all three cache AWS credentials in-process). The restart still fires only when the access key actually changed, so there is no extra churn.

This is intentionally the **minimal** fix that preserves the existing `docs/imds-secured-design.md` architecture (a root-side timer fetches IMDS creds into a tmpfs file because, under `Imds.Secured=true`, the `nobody` UID inside the container cannot reach IMDS directly). Restarting the process is the only reliable way to make the AWS SDK drop its cached static credentials — a config reload (`SIGHUP`) reloads scrape config but does **not** re-init the credentials provider.

A deeper fix that removes this class of bug entirely is already noted in that design doc under *"What would change this design"*: replace `ec2_sd_configs` with the **Slurm 25.11 native `/metrics` endpoints** for node discovery, after which Prometheus needs no AWS credentials at all (no file, no refresh timer, no restart). That is a larger change (the doc's "Phase 3"); this PR is the small, backward-compatible stopgap until then.

## Verification (live AWS PCS login node)

- **Reproduced**: a login node up ~17h showed continuous `RequestExpired` starting ~6.5h after boot (the first credential rotation); EC2 SD had zero compute targets while the slurm/HeadNode static targets stayed `up`.
- **Confirmed the cause**: `docker restart prometheus` immediately cleared the errors and re-discovered the compute node — proving the on-disk creds were fine and the in-process cache was the problem.
- **Confirmed the fix**: applied this change, forced an access-key change, ran the refresh script → prometheus restarted → with a running compute node, EC2 SD reported the `:9100` target `up`, `node_load1{instance_name="Compute"}` returned a live value, and `RequestExpired` over the following 5 minutes was **0**.
- **Reproduced independently on a clean, untouched cluster** (shipped monitoring, no local edits): invalidating the token gave `AuthFailure` and dropped the compute target 1→0; applying the fix + a key change restarted prometheus and recovered the target to `up` with 0 errors.

## Restart side-effects (checked — negligible)

- **Frequency**: the restart fires only when the access key actually changed, not on every 5-min tick (verified: two back-to-back same-key refreshes did not restart prometheus). IMDS rotates ~every 6h → ~4 restarts/day.
- **Downtime**: prometheus was back to `/-/ready` in **~1 s**.
- **No data loss**: the TSDB is a persistent Docker volume; the WAL replayed cleanly on restart, and a range query over the 30 min spanning a restart showed continuous 60 s-step samples with **no gap > 120 s** — the 1 s downtime is absorbed within the scrape interval.

Changes one file: `custom-metrics/refresh-ec2-credentials.sh`.
